### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-LineRider.yml
+++ b/.github/workflows/Build-LineRider.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v2.5.0
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v2.5.0
           
       - name: Get next version
         uses: reecetech/version-increment@2022.5.1
@@ -18,7 +18,7 @@ jobs:
           increment: patch
         
       - name: Make Changelog
-        uses: johnyherangi/create-release-notes@v1.0.0
+        uses: johnyherangi/create-release-notes@v1.0.1
         id: create-release-notes
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  

--- a/.github/workflows/Update-Version-Files.yml
+++ b/.github/workflows/Update-Version-Files.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@v2.5.0
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo

--- a/.github/workflows/Upload-Files.yml
+++ b/.github/workflows/Upload-Files.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v2.5.0
         
       - name: Download workflow artifact
         uses: benday-inc/download-latest-artifact@v2.1

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v2.5.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)** published a new release [v1.1.3](https://github.com/microsoft/setup-msbuild/releases/tag/v1.1.3) on 2022-10-12T23:14:26Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
* **[johnyherangi/create-release-notes](https://github.com/johnyherangi/create-release-notes)** published a new release [v1.0.1](https://github.com/johnyherangi/create-release-notes/releases/tag/v1.0.1) on 2022-09-23T12:24:29Z
