### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-LineRider.yml
+++ b/.github/workflows/Build-LineRider.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3.0.2
+      uses: actions/checkout@v2.5.0
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v1.1.3
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -37,13 +37,13 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: ren Build linerider
       
-    - uses: actions/upload-artifact@v3.1.0
+    - uses: actions/upload-artifact@v3.1.1
       with:
         name: linerider
         path: linerider
   
     - name: Invoke workflow without inputs
-      uses: benc-uk/workflow-dispatch@v1.1
+      uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Create Release
         token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v2.5.0
           
       - name: Get next version
-        uses: reecetech/version-increment@2022.5.1
+        uses: reecetech/version-increment@2022.10.3
         id: version
         with:
           scheme: calver
           increment: patch
         
       - name: Make Changelog
-        uses: johnyherangi/create-release-notes@v1.0.0
+        uses: johnyherangi/create-release-notes@v1.0.1
         id: create-release-notes
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
@@ -47,7 +47,7 @@ jobs:
           prerelease: false
           
       - name: Invoke workflow without inputs
-        uses: benc-uk/workflow-dispatch@v1.1
+        uses: benc-uk/workflow-dispatch@v1.2.2
         with:
           workflow: Upload Files
           token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/Update-Version-Files.yml
+++ b/.github/workflows/Update-Version-Files.yml
@@ -8,13 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.0.2
+    - uses: actions/checkout@v2.5.0
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
         
     - name: Get next version
-      uses: reecetech/version-increment@2022.5.1
+      uses: reecetech/version-increment@2022.10.3
       id: version
       with:
         scheme: calver
@@ -36,7 +36,7 @@ jobs:
         branch: linux
         
     - name: Invoke workflow without inputs
-      uses: benc-uk/workflow-dispatch@v1.1
+      uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Build LineRider
         token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/Upload-Files.yml
+++ b/.github/workflows/Upload-Files.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v2.5.0
         
       - name: Download workflow artifact
-        uses: benday-inc/download-latest-artifact@v2.1
+        uses: benday-inc/download-latest-artifact@v2.2
         with:
           token: ${{ secrets.PERSONAL_TOKEN }}
           repository_owner: 'Sussy-OS'

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v2.5.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.5.6
+        uses: saadmk11/github-actions-version-updater@v0.7.1
         with:
           # Optional, This will be used to configure git
           # defaults to `github-actions[bot]` if not provided


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[benc-uk/workflow-dispatch](https://github.com/benc-uk/workflow-dispatch)** published a new release [v1.2.2](https://github.com/benc-uk/workflow-dispatch/releases/tag/v1.2.2) on 2022-11-06T00:02:04Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release [v0.7.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.1) on 2022-10-29T16:38:42Z
* **[johnyherangi/create-release-notes](https://github.com/johnyherangi/create-release-notes)** published a new release [v1.0.1](https://github.com/johnyherangi/create-release-notes/releases/tag/v1.0.1) on 2022-09-23T12:24:29Z
* **[microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)** published a new release [v1.1.3](https://github.com/microsoft/setup-msbuild/releases/tag/v1.1.3) on 2022-10-12T23:14:26Z
* **[benday-inc/download-latest-artifact](https://github.com/benday-inc/download-latest-artifact)** published a new release [v2.2](https://github.com/benday-inc/download-latest-artifact/releases/tag/v2.2) on 2022-10-20T15:35:48Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release [v3.1.1](https://github.com/actions/upload-artifact/releases/tag/v3.1.1) on 2022-10-21T19:20:02Z
* **[reecetech/version-increment](https://github.com/reecetech/version-increment)** published a new release [2022.10.3](https://github.com/reecetech/version-increment/releases/tag/2022.10.3) on 2022-10-19T03:28:38Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
