### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.0
         with:
           # Optional, This will be used to configure git
           # defaults to `github-actions[bot]` if not provided


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
