### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.8.0
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # Optional, This will be used to configure git
           # defaults to `github-actions[bot]` if not provided


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
