### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-LineRider.yml
+++ b/.github/workflows/Build-LineRider.yml
@@ -37,7 +37,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: ren Build linerider
       
-    - uses: actions/upload-artifact@v3.1.3
+    - uses: actions/upload-artifact@v4.3.0
       with:
         name: linerider
         path: linerider


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.0](https://github.com/actions/upload-artifact/releases/tag/v4.3.0)** on 2024-01-23T17:40:41Z
