### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-LineRider.yml
+++ b/.github/workflows/Build-LineRider.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4.1.1
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.3.1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)** published a new release **[v2](https://github.com/microsoft/setup-msbuild/releases/tag/v2)** on 2024-01-31T01:06:10Z
