### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-LineRider.yml
+++ b/.github/workflows/Build-LineRider.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4.1.6
+      uses: actions/checkout@v4.1.7
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
@@ -37,13 +37,13 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: ren Build linerider
       
-    - uses: actions/upload-artifact@v4.3.3
+    - uses: actions/upload-artifact@v4.3.5
       with:
         name: linerider
         path: linerider
   
     - name: Invoke workflow without inputs
-      uses: benc-uk/workflow-dispatch@v1.2.3
+      uses: benc-uk/workflow-dispatch@v1.2.4
       with:
         workflow: Create Release
         token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/Create-Release.yml
+++ b/.github/workflows/Create-Release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
           
       - name: Get next version
         uses: reecetech/version-increment@2024.4.4
@@ -47,7 +47,7 @@ jobs:
           prerelease: false
           
       - name: Invoke workflow without inputs
-        uses: benc-uk/workflow-dispatch@v1.2.3
+        uses: benc-uk/workflow-dispatch@v1.2.4
         with:
           workflow: Upload Files
           token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/Update-Version-Files.yml
+++ b/.github/workflows/Update-Version-Files.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.6
+    - uses: actions/checkout@v4.1.7
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
@@ -33,7 +33,7 @@ jobs:
         branch: linux
         
     - name: Invoke workflow without inputs
-      uses: benc-uk/workflow-dispatch@v1.2.3
+      uses: benc-uk/workflow-dispatch@v1.2.4
       with:
         workflow: Build LineRider
         token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/Upload-Files.yml
+++ b/.github/workflows/Upload-Files.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
         
       - name: Download workflow artifact
         uses: benday-inc/download-latest-artifact@v2.2

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[benc-uk/workflow-dispatch](https://github.com/benc-uk/workflow-dispatch)** published a new release **[v1.2.4](https://github.com/benc-uk/workflow-dispatch/releases/tag/v1.2.4)** on 2024-08-03T09:39:19Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.5](https://github.com/actions/upload-artifact/releases/tag/v4.3.5)** on 2024-08-02T14:02:19Z
